### PR TITLE
Remove default context value

### DIFF
--- a/preact/context.js
+++ b/preact/context.js
@@ -1,3 +1,3 @@
 var Preact = require('preact')
 
-module.exports = Preact.createContext('storeon')
+module.exports = Preact.createContext()

--- a/react/context.js
+++ b/react/context.js
@@ -13,4 +13,4 @@ var React = require('react')
  * @name StoreContext
  * @type {Context}
  */
-module.exports = React.createContext('storeon')
+module.exports = React.createContext()


### PR DESCRIPTION
The default value is not used anywhere.
Also, it adds `6B` to bundle size.