### PR TITLE
Allow using symbol as an event name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 export type Dispatch = {
-  (event: string, data?: any): void;
+  (event: PropertyKey, data?: any): void;
 };
 
 export interface Store<T> {
   on: (
-    event: string,
+    event: PropertyKey,
     handler: (state: Readonly<T>, data: any) => Partial<T> | null
   ) => () => void;
   dispatch: Dispatch;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -138,4 +138,22 @@ it('allows symbol as a store key', function () {
 
   expect(store.get()[a]).toBe(1)
 })
+
+it('allows symbol as an event name', function () {
+  var inc = Symbol('inc')
+
+  function init (store) {
+    store.on('@init', function () {
+      return { a: 0 }
+    })
+  }
+  var store = createStore([init])
+  store.on(inc, function () {
+    return { a: 1 }
+  })
+
+  store.dispatch(inc, 'a')
+
+  expect(store.get().a).toBe(1)
+})
 /* eslint-enable es5/no-computed-properties */


### PR DESCRIPTION
This PR allows using `Symbol` as an event name. Current project code already allows doing it, so only Typescript typings are changed.