### PR TITLE
Stringify event name to work with symbols correctly

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -40,7 +40,7 @@ function devtools (options) {
 
     var prev = ''
     store.on('@dispatch', function (state, data) {
-      var event = data[0]
+      var event = String(data[0])
       if (event !== 'UPDATE_FROM_DEVTOOLS' && prev !== 'UPDATE_FROM_DEVTOOLS') {
         if (event[0] !== '@' && (!data[2] || data[2].length === 0)) {
           throw new Error('Unknown Storeon event ' + event)

--- a/devtools/logger.browser.js
+++ b/devtools/logger.browser.js
@@ -7,9 +7,9 @@ module.exports = function (store) {
       var keys = Object.keys(data[1]).join(', ')
       console.log('%cchanged %c' + keys, STYLE, BOLD, state)
     } else if (data[1]) {
-      console.log('%caction %c' + data[0], STYLE, BOLD, data[1])
+      console.log('%caction %c' + String(data[0]), STYLE, BOLD, data[1])
     } else {
-      console.log('%caction %c' + data[0], STYLE, BOLD)
+      console.log('%caction %c' + String(data[0]), STYLE, BOLD)
     }
   })
 }

--- a/devtools/logger.js
+++ b/devtools/logger.js
@@ -18,9 +18,9 @@ module.exports = function (store) {
       var keys = Object.keys(data[1]).join(', ')
       console.log('changed ' + keys, state)
     } else if (data[1]) {
-      console.log('action ' + data[0], data[1])
+      console.log('action ' + String(data[0]), data[1])
     } else {
-      console.log('action ' + data[0])
+      console.log('action ' + String(data[0]))
     }
   })
 }


### PR DESCRIPTION
This PR fixes devtools functions to work with symbols correctly. Now it puts symbolic properties as `Symbol(propertyName)`:

<img src="https://user-images.githubusercontent.com/8037479/56093480-0619ad80-5ed2-11e9-9a13-fada66018cc7.png" width="400px">