### PR TITLE
Update `@dispatch` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ There are three built-in events:
 To add an event listener, call `store.on()` with event name and callback.
 
 ```js
-store.on('@dispatch', ([event, data]) => {
+store.on('@dispatch', (state, [event, data]) => {
   console.log(`Storeon: ${ event } with `, data)
 })
 ```


### PR DESCRIPTION
`@dispatch` processes the same way as any other event, with the current state passed as the first variable.

This lead to a bit of confusion when I attempted to use this library for the first time, until I realized that state was being passed as well. This may or may not be the desired behavior, but I'm updating the documentation to how it has worked since implementation.